### PR TITLE
Landing redesign: text brand, clone box, live results summary

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,9 +27,9 @@ unsafe = true
 ############################# Default Parameters ##########################
 [Params]
 # logo is for all page
-logo = "/images/OpenACCVVdark.png"
+logo = ""
 # logo white is for homepage logo, you can use colorful logo too...
-logo_white = "/images/OpenACCVVwhite.png"
+logo_white = ""
 # when logo is empty, it will shown your site title
 
 # OpenGraph / Twitter Card metadata
@@ -107,7 +107,7 @@ content = "This website contains how-to-run & visualize the OpenACC V&V testsuit
 
 # call to action
 [Languages.en.params.cta]
-enable = true
+enable = false
 title = "Just ask. Get answers."
 content = "Your questions and comments are important to us."
 # call to action button

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,82 @@
+{{ define "main" }}
+
+<header class="banner {{if .Site.Params.banner.bg_image}}overlay bg-cover{{else}}bg-primary{{end}}" data-background="{{ .Site.Params.banner.bg_image | absURL }}">
+  {{ partialCached "banner.html" . }}
+</header>
+
+{{ if .Site.Params.welcome.enable }}{{ with .Site.Params.welcome }}
+<section class="section">
+  <div class="container"><div class="row"><div class="col-12 text-center">
+    <h2 class="mb-4">{{ .title | markdownify }}</h2>
+    <p style="font-size:20px" class="mb-4">{{ .content | markdownify }}</p>
+  </div></div></div>
+</section>
+{{ end }}{{ end }}
+
+{{ "<!-- clone the testsuite -->" | safeHTML }}
+<section class="section pt-0">
+  <div class="container"><div class="row justify-content-center"><div class="col-lg-9 text-center">
+    <h3 class="mb-3">Get the testsuite</h3>
+    <p class="mb-4 text-muted">Clone the OpenACC V&amp;V testsuite and follow the README to build and run it.</p>
+    <div class="clone-box">
+      <code id="vv-clone">git clone https://github.com/OpenACCUserGroup/OpenACCV-V.git</code>
+      <button type="button" id="vv-clone-btn">Copy</button>
+    </div>
+  </div></div></div>
+</section>
+
+{{ "<!-- latest results summary -->" | safeHTML }}
+<section class="section bg-light">
+  <div class="container">
+    <div class="row justify-content-center"><div class="col-12 text-center">
+      <h2 class="section-title">Latest Results</h2>
+      <p class="mb-4" id="vv-sum-sub">&nbsp;</p>
+    </div></div>
+    <div id="vv-summary">Loading latest results…</div>
+    <div class="text-center mt-4"><a href="results" class="btn btn-primary">View full results table</a></div>
+  </div>
+</section>
+
+<script>
+(function(){
+  var b=document.getElementById('vv-clone-btn');
+  if(b) b.addEventListener('click',function(){
+    var t=document.getElementById('vv-clone').textContent.trim();
+    var done=function(){ b.textContent='Copied'; setTimeout(function(){b.textContent='Copy';},1500); };
+    if(navigator.clipboard&&navigator.clipboard.writeText){ navigator.clipboard.writeText(t).then(done,done); }
+    else { var ta=document.createElement('textarea'); ta.value=t; document.body.appendChild(ta); ta.select(); try{document.execCommand('copy');}catch(e){} document.body.removeChild(ta); done(); }
+  });
+
+  var NAMES={nvc:'NVIDIA nvc',GCC:'GNU GCC',Cray:'HPE Cray',Clacc:'Clacc'};
+  var esc=function(s){return String(s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});};
+  var ncmp=function(a,b){return String(a).localeCompare(String(b),undefined,{numeric:true});};
+  fetch('results-data/combined.json').then(function(r){return r.json();}).then(function(d){
+    var runs=d.runs, vendors=[]; runs.forEach(function(r){if(vendors.indexOf(r.vendor)<0)vendors.push(r.vendor);});
+    vendors.sort();
+    var html='';
+    vendors.forEach(function(v){
+      var idx=runs.map(function(r,i){return r.vendor===v?i:-1;}).filter(function(i){return i>=0;});
+      var mx=idx[0]; idx.forEach(function(i){ if(ncmp(runs[i].version,runs[mx].version)>0) mx=i; });
+      var r=runs[mx], cells=r.cells, cnt={P:0,C:0,R:0,X:0,U:0}, present=0;
+      for(var k=0;k<cells.length;k++){ var c=cells[k]; if(c==='.')continue; present++; if(c==='E')c='R'; if(cnt[c]!=null)cnt[c]++; }
+      if(!present) return;
+      var pct=Math.round(100*cnt.P/present);
+      var seg=function(cls,n){ return n? '<span class="'+cls+'" style="width:'+(100*n/present)+'%"></span>':''; };
+      html+='<div class="vv-bar-row">'+
+        '<div class="vv-bar-lab">'+esc(NAMES[v]||v)+'<small>'+esc(r.version)+'</small></div>'+
+        '<div class="vv-bar">'+seg('sP',cnt.P)+seg('sC',cnt.C)+seg('sR',cnt.R)+seg('sU',cnt.U)+seg('sX',cnt.X)+'</div>'+
+        '<div class="vv-bar-pct">'+pct+'%</div></div>';
+    });
+    html+='<div class="vv-sum-legend">'+
+      '<span><i style="background:#1e9e57"></i>Pass</span>'+
+      '<span><i style="background:#cf3030"></i>Compiler error</span>'+
+      '<span><i style="background:#e8820c"></i>Runtime error / failure</span>'+
+      '<span><i style="background:#6f54b8"></i>Unknown</span>'+
+      '<span><i style="background:#cdd5dd"></i>Excluded</span></div>';
+    document.getElementById('vv-summary').innerHTML=html;
+    var sub=document.getElementById('vv-sum-sub'); if(sub) sub.textContent='Pass rate of the newest version of each compiler · '+d.tests.length+' tests · updated nightly';
+  }).catch(function(e){ document.getElementById('vv-summary').textContent='Could not load results ('+e+').'; });
+})();
+</script>
+
+{{ end }}

--- a/static/css/nav-overrides.css
+++ b/static/css/nav-overrides.css
@@ -25,4 +25,28 @@
   margin-top: 24px;
 }
 
+/* --- BRAND: logo replaced with bold "OpenACC V&V" text --- */
+.navbar-brand{font-weight:800;font-size:1.5rem;letter-spacing:.3px}
+.navbar-dark .navbar-brand{color:#fff}
+.navbar-light .navbar-brand{color:#122654}
+
+/* --- HOME: clone box with copy button --- */
+.clone-box{display:inline-flex;align-items:stretch;max-width:580px;width:100%;border:1px solid #d4dbe2;border-radius:8px;overflow:hidden;background:#0f1b2d}
+.clone-box code{flex:1;padding:12px 16px;color:#e8eef5;font-size:15px;text-align:left;white-space:nowrap;overflow:auto;background:transparent;font-family:SFMono-Regular,Consolas,Menlo,monospace}
+.clone-box button{border:0;background:#122654;color:#fff;padding:0 18px;font-weight:600;cursor:pointer;font-size:14px;white-space:nowrap}
+.clone-box button:hover{background:#1d3a6b}
+
+/* --- HOME: latest-results summary bars --- */
+.vv-summary{max-width:820px;margin:0 auto}
+.vv-bar-row{display:flex;align-items:center;gap:14px;margin:13px 0}
+.vv-bar-lab{width:150px;text-align:right;font-weight:700;color:#122654;line-height:1.15}
+.vv-bar-lab small{display:block;font-weight:500;color:#7a8794;font-size:12px}
+.vv-bar{flex:1;display:flex;height:26px;border-radius:5px;overflow:hidden;box-shadow:inset 0 0 0 1px #e1e6eb}
+.vv-bar span{display:block}
+.vv-bar .sP{background:#1e9e57}.vv-bar .sC{background:#cf3030}.vv-bar .sR{background:#e8820c}.vv-bar .sX{background:#cdd5dd}.vv-bar .sU{background:#6f54b8}
+.vv-bar-pct{width:54px;text-align:left;font-weight:700;color:#1e9e57}
+.vv-sum-legend{display:flex;gap:16px;justify-content:center;flex-wrap:wrap;margin-top:20px;font-size:13px;color:#5b6b7b}
+.vv-sum-legend span{display:inline-flex;align-items:center;gap:6px}
+.vv-sum-legend i{width:13px;height:13px;border-radius:3px;display:inline-block}
+
 


### PR DESCRIPTION
Refreshes the homepage and branding.

**Branding**
- Replace the logo image with bold **OpenACC V&V** text (empty `logo`/`logo_white` params + `.navbar-brand` styling in nav-overrides.css).

**Homepage**
- Add a **git clone box with a Copy button** for `OpenACCUserGroup/OpenACCV-V`.
- Add a **Latest Results** summary: horizontal pass/CE/RE/excluded bars for the **newest version of each compiler**, read live from the nightly `combined.json` (so it changes as results update), with a link to the full results table.
- Remove the **"Just ask. Get answers."** CTA and the **Resources / Members / Publications / Getting-Started** topic cards.

The summary bars share the same data source as the Results page (`/results-data/combined.json`).