### PR TITLE
Landing polish: larger brand text + tighter spacing

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,19 +5,19 @@
 </header>
 
 {{ if .Site.Params.welcome.enable }}{{ with .Site.Params.welcome }}
-<section class="section">
-  <div class="container"><div class="row"><div class="col-12 text-center">
-    <h2 class="mb-4">{{ .title | markdownify }}</h2>
-    <p style="font-size:20px" class="mb-4">{{ .content | markdownify }}</p>
+<section class="section home-tight">
+  <div class="container"><div class="row justify-content-center"><div class="col-lg-10 text-center">
+    <h2 class="mb-2">{{ .title | markdownify }}</h2>
+    <p style="font-size:18px" class="mb-0">{{ .content | markdownify }}</p>
   </div></div></div>
 </section>
 {{ end }}{{ end }}
 
 {{ "<!-- clone the testsuite -->" | safeHTML }}
-<section class="section pt-0">
+<section class="section home-tight pt0">
   <div class="container"><div class="row justify-content-center"><div class="col-lg-9 text-center">
-    <h3 class="mb-3">Get the testsuite</h3>
-    <p class="mb-4 text-muted">Clone the OpenACC V&amp;V testsuite and follow the README to build and run it.</p>
+    <h3 class="mb-2">Get the testsuite</h3>
+    <p class="mb-3 text-muted">Clone the OpenACC V&amp;V testsuite and follow the README to build and run it.</p>
     <div class="clone-box">
       <code id="vv-clone">git clone https://github.com/OpenACCUserGroup/OpenACCV-V.git</code>
       <button type="button" id="vv-clone-btn">Copy</button>
@@ -26,14 +26,14 @@
 </section>
 
 {{ "<!-- latest results summary -->" | safeHTML }}
-<section class="section bg-light">
+<section class="section home-tight bg-light">
   <div class="container">
     <div class="row justify-content-center"><div class="col-12 text-center">
-      <h2 class="section-title">Latest Results</h2>
-      <p class="mb-4" id="vv-sum-sub">&nbsp;</p>
+      <h2 class="section-title mb-2">Latest Results</h2>
+      <p class="mb-3" id="vv-sum-sub">&nbsp;</p>
     </div></div>
     <div id="vv-summary">Loading latest results…</div>
-    <div class="text-center mt-4"><a href="results" class="btn btn-primary">View full results table</a></div>
+    <div class="text-center mt-3"><a href="results" class="btn btn-primary">View full results table</a></div>
   </div>
 </section>
 

--- a/static/css/nav-overrides.css
+++ b/static/css/nav-overrides.css
@@ -26,9 +26,13 @@
 }
 
 /* --- BRAND: logo replaced with bold "OpenACC V&V" text --- */
-.navbar-brand{font-weight:800;font-size:1.5rem;letter-spacing:.3px}
+.navbar .navbar-brand{font-weight:900;font-size:2.1rem;letter-spacing:.4px;line-height:1;padding-top:.1rem;padding-bottom:.1rem}
 .navbar-dark .navbar-brand{color:#fff}
 .navbar-light .navbar-brand{color:#122654}
+
+/* --- HOME: tighter section spacing --- */
+.home-tight{padding-top:2.2rem !important;padding-bottom:2.2rem !important}
+.home-tight.pt0{padding-top:0 !important}
 
 /* --- HOME: clone box with copy button --- */
 .clone-box{display:inline-flex;align-items:stretch;max-width:580px;width:100%;border:1px solid #d4dbe2;border-radius:8px;overflow:hidden;background:#0f1b2d}


### PR DESCRIPTION
- **Brand**: bold `OpenACC V&V` text bumped to 2.1rem / weight 900 with a higher-specificity selector so the theme can't shrink it.
- **Homepage spacing**: section padding reduced from the theme's ~80px to ~35px and heading/paragraph gaps tightened, so Welcome / Clone / Latest Results sit closer together.